### PR TITLE
Default to window.location if no arguments

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,10 @@ function encode (o, sep) {
 
 var REXP_SPLIT = /&amp;|&|;/gmi;
 function decode (str, sep) {
+    if(!str && window) {
+        str = window.location.search.substring(1);
+    }
+
     sep = sep||REXP_SPLIT;
     var result = {};
     var expr = str.split(sep);


### PR DESCRIPTION
If no string is given, and the module is used in the browser,
then default to window.location.

Makes for cleaner code in frontend code.
